### PR TITLE
Text sample data is a list and not a string

### DIFF
--- a/django_any/models.py
+++ b/django_any/models.py
@@ -412,7 +412,7 @@ def any_text_field(field, **kwargs):
     >>> result[0] == COMMON_P
     True
     """
-    return paragraphs(10)
+    return str(paragraphs(10))
 
 
 @any_field.register(models.URLField)


### PR DESCRIPTION
paragraph() returns a list, not a string. In most cases you would not notice, as after saving to a Textfield its a pure string.
